### PR TITLE
Release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "size-limit": [
         {
             "path": "dist",
-            "limit": "1.5 kB"
+            "limit": "1.99 kB"
         }
     ],
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tikjs",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "description": "Fast lightweight library for formatting time in JavaScript",
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/TikJSTime/TikJSTime.ts
+++ b/src/TikJSTime/TikJSTime.ts
@@ -21,6 +21,7 @@ export class TikJSTime {
     public static dates = {
         /**
          * @deprecated Pass the dates as arguments to `tikjs()` instead.
+         * ---
          * Get the duration between two or more dates. The order
          * of the dates can be ascending or descending.
          * @param dates - The dates to compare.

--- a/src/TikJSTime/TikJSTime.ts
+++ b/src/TikJSTime/TikJSTime.ts
@@ -64,46 +64,59 @@ export class TikJSTime {
     };
 
     constructor(time: TikJSInput) {
-        if (time === Number(0)) return;
-        let unit = "s";
-        let _time = time;
+        if (time === 0) return;
+
+        const timeCollection = [];
+        let seconds = 0;
+
         if (typeof time === "string") {
-            const match = time.match(/(\d+)\s*([yMdHmsS])/);
-            if (match !== null) {
-                _time = match[1];
-                unit = match[2];
+            const regex = /(\d+)\s*([yMdHmsS])?/g;
+            let match;
+            const matches = [];
+
+            while ((match = regex.exec(time)) !== null) {
+                matches.push(match);
+            }
+
+            for (const match of matches) {
+                timeCollection.push([match[1], match[2] || "s"]);
             }
         }
 
-        switch (unit) {
-            case "y":
-                _time = Number(_time) * SECONDS_IN_A_YEAR;
-                break;
-            case "M":
-                _time = Number(_time) * SECONDS_IN_A_MONTH;
-                break;
-            case "d":
-                _time = Number(_time) * SECONDS_IN_A_DAY;
-                break;
-            case "H":
-                _time = Number(_time) * SECONDS_IN_AN_HOUR;
-                break;
-            case "m":
-                _time = Number(_time) * SECONDS_IN_A_MINUTE;
-                break;
-            case "s":
-                _time = Number(_time);
-                break;
-            case "S":
-                _time = Number(_time) / MILLISECONDS_IN_A_SECOND;
-                break;
-            default:
-                throw new Error(
-                    `Valid units: "y", "M", "d", "H", "m", "s" or "S".`,
-                );
+        if (timeCollection.length === 0) {
+            timeCollection.push([time, "s"]);
         }
 
-        const seconds = Number(_time);
+        for (const [_time, unit] of timeCollection) {
+            switch (unit) {
+                case "y":
+                    seconds += Number(_time) * SECONDS_IN_A_YEAR;
+                    break;
+                case "M":
+                    seconds += Number(_time) * SECONDS_IN_A_MONTH;
+                    break;
+                case "d":
+                    seconds += Number(_time) * SECONDS_IN_A_DAY;
+                    break;
+                case "H":
+                    seconds += Number(_time) * SECONDS_IN_AN_HOUR;
+                    break;
+                case "m":
+                    seconds += Number(_time) * SECONDS_IN_A_MINUTE;
+                    break;
+                case "s":
+                    seconds += Number(_time);
+                    break;
+                case "S":
+                    seconds += Number(_time) / MILLISECONDS_IN_A_SECOND;
+                    break;
+                default:
+                    throw new Error(
+                        `Valid units: "y", "M", "d", "H", "m", "s" or "S".`,
+                    );
+            }
+        }
+
         if (seconds === 0) return;
         if (isNaN(seconds)) {
             throw new Error(

--- a/src/TikJSTime/TikJSTime.ts
+++ b/src/TikJSTime/TikJSTime.ts
@@ -70,7 +70,7 @@ export class TikJSTime {
         let seconds = 0;
 
         if (typeof time === "string") {
-            const regex = /(\d+)\s*([yMdHmsS])?/g;
+            const regex = /(\d+.?\d+?)\s*([yMdHmsS])?/g;
             let match;
             const matches = [];
 

--- a/src/TikJSTime/TikJSTime.ts
+++ b/src/TikJSTime/TikJSTime.ts
@@ -64,11 +64,50 @@ export class TikJSTime {
     };
 
     constructor(time: TikJSInput) {
-        const seconds = Number(time);
+        if (time === Number(0)) return;
+        let unit = "s";
+        let _time = time;
+        if (typeof time === "string") {
+            const match = time.match(/(\d+)\s*([yMdHmsS])/);
+            if (match !== null) {
+                _time = match[1];
+                unit = match[2];
+            }
+        }
+
+        switch (unit) {
+            case "y":
+                _time = Number(_time) * SECONDS_IN_A_YEAR;
+                break;
+            case "M":
+                _time = Number(_time) * SECONDS_IN_A_MONTH;
+                break;
+            case "d":
+                _time = Number(_time) * SECONDS_IN_A_DAY;
+                break;
+            case "H":
+                _time = Number(_time) * SECONDS_IN_AN_HOUR;
+                break;
+            case "m":
+                _time = Number(_time) * SECONDS_IN_A_MINUTE;
+                break;
+            case "s":
+                _time = Number(_time);
+                break;
+            case "S":
+                _time = Number(_time) / MILLISECONDS_IN_A_SECOND;
+                break;
+            default:
+                throw new Error(
+                    `Valid units: "y", "M", "d", "H", "m", "s" or "S".`,
+                );
+        }
+
+        const seconds = Number(_time);
         if (seconds === 0) return;
         if (isNaN(seconds)) {
             throw new Error(
-                `The time "${time}" is not a valid number or string that can be converted to a number.`,
+                `Not a valid number or string that can be converted to a number.`,
             );
         }
         this.years = seconds / SECONDS_IN_A_YEAR;
@@ -84,11 +123,7 @@ export class TikJSTime {
         const blocksPattern = /(yy?|MM?|dd?|hh?|mm?|ss?|SS?|\[[^\]]+\])/g;
         const thereAreNoBlocks = format.match(blocksPattern) === null;
 
-        if (thereAreNoBlocks) {
-            throw new Error(
-                `The time pattern "${format}" must contain at least one of the following blocks: "h", "hh", "m", "mm", "s" or "ss".`,
-            );
-        }
+        if (thereAreNoBlocks) return format;
 
         const wholeYears = Math.floor(this.years);
         const wholeMonths = Math.floor(this.months) % 12;

--- a/src/TikJSTime/tests/format.test.ts
+++ b/src/TikJSTime/tests/format.test.ts
@@ -7,20 +7,6 @@ describe("TikJSTime — format", () => {
         expect(formattedTime).toBe("00:10:00");
     });
 
-    it("should throw an error if the format string is empty", () => {
-        const time = new TikJSTime(600);
-        expect(() => time.format("")).toThrow(
-            'The time pattern "" must contain at least one of the following blocks: "h", "hh", "m", "mm", "s" or "ss".',
-        );
-    });
-
-    it("should throw an error if the format string has no blocks", () => {
-        const time = new TikJSTime(600);
-        expect(() => time.format("abc")).toThrow(
-            'The time pattern "abc" must contain at least one of the following blocks: "h", "hh", "m", "mm", "s" or "ss".',
-        );
-    });
-
     it("should escape blocks with square brackets", () => {
         const time = new TikJSTime(601);
         const formattedTime = time.format("Ti[m]e: mm:ss");

--- a/src/tikjs/tikjs.ts
+++ b/src/tikjs/tikjs.ts
@@ -1,34 +1,52 @@
 import { type TikJSInput, TikJSTime } from "../TikJSTime";
 
 /**
- * @param time - The time to be converted. It must be a number or string representing seconds.
- * @returns A new TikJSTime instance. It represents the time in years, months, days,
- * hours, minutes, seconds and milliseconds. Also it has a method to format the time.
- * To format the time, you can use the following blocks:
- * - `y` or `yy`: years
- * - `M` or `MM`: months
- * - `d` or `dd`: days
- * - `h` or `hh`: hours
- * - `m` or `mm`: minutes
- * - `s` or `ss`: seconds
- * - `S` or `SS`: milliseconds
- * - `[...]`: any text inside the brackets will be displayed as is
- * @throws If the time pattern does not contain any of the following
- * blocks: "h", "hh", "m", "mm", "s" or "ss".
+ * **Tik.js** is a library to work with time in JavaScript. It allows you to easily
+ * parse time to get durations, format them, and add or subtract time from dates.
+ *
+ * @param time - The time to work with. It can be a number, a string or undefined.
+ * If it's a number, it will be considered as a duration in seconds.
+ * If it's a string, you can specify the unit of time by adding a suffix.
+ * For example, "1d" for 1 day.
+ *
+ * Unit of time suffixes:
+ * - `s` for seconds
+ * - `m` for minutes
+ * - `h` for hours
+ * - `d` for days
+ * - `M` for months
+ * - `y` for years
+ *
+ * If the time is undefined, it will return the TikJSTime class, which will give
+ * you access to the dates methods.
+ *
+ * @returns The TikJSTime instance if the time is defined, or the TikJSTime class if it's not.
  * @example
  * ```javascript
- * import tikjs from "tikjs";
- *
- * const time = tikjs(60);
- *
- * console.log(time.format("Ti[m]e: m:ss")); // Time: 1:00
+ * const time = tikjs(3600); // 1 hour
+ * console.log(time.hours); // 1
+ * console.log(time.minutes); // 60
+ * console.log(time.seconds); // 3600
+ * console.log(time.format("h:mm:ss")); // 1:00:00
+ * ```
+ * @example
+ * ```javascript
+ * const currentDate = new Date();
+ * const newDate = tikjs().dates.add(currentDate, "1d");
+ * console.log(newDate); // Adds 1 day to the current date.
  * ```
  */
 function tikjs(): typeof TikJSTime;
 function tikjs(time: TikJSInput): TikJSTime;
-function tikjs(time?: TikJSInput): TikJSTime | typeof TikJSTime {
+function tikjs(date1: Date, date2: Date): TikJSTime;
+function tikjs(
+    time?: TikJSInput | Date,
+    date2?: Date,
+): TikJSTime | typeof TikJSTime {
     if (time === undefined) {
         return TikJSTime;
+    } else if (time instanceof Date && date2 instanceof Date) {
+        return new TikJSTime(time, date2);
     }
     return new TikJSTime(time);
 }

--- a/src/tikjs/tikjs.ts
+++ b/src/tikjs/tikjs.ts
@@ -2,9 +2,9 @@ import { type TikJSInput, TikJSTime } from "../TikJSTime";
 
 /**
  * **Tik.js** is a library to work with time in JavaScript. It allows you to easily
- * parse time to get durations, format them, and add or subtract time from dates.
+ * parse time to get durations and format them.
  *
- * @param time - The time to work with. It can be a number, a string or undefined.
+ * @param time - The time to work with. It can be a number or string.
  * If it's a number, it will be considered as a duration in seconds.
  * If it's a string, you can specify the unit of time by adding a suffix.
  * For example, "1d" for 1 day.
@@ -17,10 +17,6 @@ import { type TikJSInput, TikJSTime } from "../TikJSTime";
  * - `M` for months
  * - `y` for years
  *
- * If the time is undefined, it will return the TikJSTime class, which will give
- * you access to the dates methods.
- *
- * @returns The TikJSTime instance if the time is defined, or the TikJSTime class if it's not.
  * @example
  * ```javascript
  * const time = tikjs(3600); // 1 hour
@@ -31,10 +27,28 @@ import { type TikJSInput, TikJSTime } from "../TikJSTime";
  * ```
  * @example
  * ```javascript
- * const currentDate = new Date();
- * const newDate = tikjs().dates.add(currentDate, "1d");
- * console.log(newDate); // Adds 1 day to the current date.
+ * const time = tikjs('1h'); // 1 hour
+ * console.log(time.hours); // 1
+ * console.log(time.minutes); // 60
+ * console.log(time.seconds); // 3600
+ * console.log(time.format("h:mm:ss")); // 1:00:00
  * ```
+ *
+ * Also, you can get the duration between two dates:
+ *
+ * @param date1 - The first date.
+ * @param date2 - The second date.
+ *
+ * @example
+ * ```javascript
+ * const date1 = new Date('2021-01-01');
+ * const date2 = new Date('2021-01-02');
+ * const time = tikjs(date1, date2);
+ * console.log(time.days); // 1
+ * console.log(time.format("d [day]")) // 1 day
+ * ```
+ *
+ * @returns A TikJSTime object.
  */
 function tikjs(): typeof TikJSTime;
 function tikjs(time: TikJSInput): TikJSTime;

--- a/src/utils/parseTimeToSeconds.ts
+++ b/src/utils/parseTimeToSeconds.ts
@@ -1,0 +1,63 @@
+import {
+    MILLISECONDS_IN_A_SECOND,
+    SECONDS_IN_A_DAY,
+    SECONDS_IN_A_MINUTE,
+    SECONDS_IN_A_MONTH,
+    SECONDS_IN_A_YEAR,
+    SECONDS_IN_AN_HOUR,
+} from "../utils/timeEquivalences";
+
+export default function parseTimeToSeconds(time: string | number): number {
+    const timeCollection = [];
+    let seconds = 0;
+
+    if (typeof time === "string") {
+        const regex = /(\d+\.?\d*)\s*([yMdhmsS])?/g;
+        let match;
+        const matches = [];
+
+        while ((match = regex.exec(time)) !== null) {
+            matches.push(match);
+        }
+
+        for (const match of matches) {
+            timeCollection.push([match[1], match[2] || "s"]);
+        }
+    }
+
+    if (timeCollection.length === 0) {
+        timeCollection.push([time, "s"]);
+    }
+
+    for (const [_time, unit] of timeCollection) {
+        switch (unit) {
+            case "y":
+                seconds += Number(_time) * SECONDS_IN_A_YEAR;
+                break;
+            case "M":
+                seconds += Number(_time) * SECONDS_IN_A_MONTH;
+                break;
+            case "d":
+                seconds += Number(_time) * SECONDS_IN_A_DAY;
+                break;
+            case "h":
+                seconds += Number(_time) * SECONDS_IN_AN_HOUR;
+                break;
+            case "m":
+                seconds += Number(_time) * SECONDS_IN_A_MINUTE;
+                break;
+            case "s":
+                seconds += Number(_time);
+                break;
+            case "S":
+                seconds += Number(_time) / MILLISECONDS_IN_A_SECOND;
+                break;
+            default:
+                throw new Error(
+                    `Valid units: "y", "M", "d", "h", "m", "s" or "S".`,
+                );
+        }
+    }
+
+    return seconds;
+}

--- a/src/utils/timeEquivalences.ts
+++ b/src/utils/timeEquivalences.ts
@@ -1,0 +1,21 @@
+/**
+ * The average year length in days.
+ *
+ * This is the average length of a year in days, taking into account leap years.
+ *
+ * A common year has 365 days, but a leap year has 366 days. We add an extra day every 4 years
+ * to account for the extra 0.25 days per year. However, century years are not leap years unless
+ * they are divisible by 400. For example, 2000 is a leap year, but 2100 is not.
+ *
+ * To do this calculation, we add 1/4 of a day every year, but subtract 1/100 of a day every year.
+ * Also add 1/400 of a day every year.
+ */
+export const AVERAGE_YEAR = 365 + 1 / 4 - 1 / 100 + 1 / 400;
+export const AVERAGE_MONTH = AVERAGE_YEAR / 12;
+export const HOURS_IN_A_DAY = 24;
+export const MILLISECONDS_IN_A_SECOND = 1000;
+export const SECONDS_IN_A_MINUTE = 60;
+export const SECONDS_IN_AN_HOUR = 60 * 60;
+export const SECONDS_IN_A_DAY = HOURS_IN_A_DAY * SECONDS_IN_AN_HOUR;
+export const SECONDS_IN_A_MONTH = AVERAGE_MONTH * SECONDS_IN_A_DAY;
+export const SECONDS_IN_A_YEAR = AVERAGE_YEAR * SECONDS_IN_A_DAY;


### PR DESCRIPTION
Now it supports unit specifier, like `10y`, `1.5m`, etc.
Also, dates key will be discontinued in the future. So `dates.getDurationBetween` is deprecated.
The new way to get the duration between two dates is `tikjs(date1, date2)`, just like any other string or number input.